### PR TITLE
expand ‘link text’ query of Selector class with ‘value’ or ‘label’ pr…

### DIFF
--- a/wda/__init__.py
+++ b/wda/__init__.py
@@ -277,9 +277,15 @@ class Alert(object):
     
 
 class Selector(object):
-    def __init__(self, base_url, text=None, class_name=None, xpath=None, index=0):
+    def __init__(self, base_url, text=None, class_name=None, xpath=None, index=0, name=None, value=None, label=None):
         self._base_url = base_url
         self._text = unicode(text) if text else None
+        if name and not self._text:
+            self._text = self._name = unicode(name)
+        else:
+            self._name = self._text
+        self._value = unicode(value) if value else None
+        self._label = unicode(label) if label else None
         self._class_name = unicode(class_name) if class_name else None
         self._xpath = unicode(xpath) if xpath else None
         self._index = index
@@ -306,9 +312,15 @@ class Selector(object):
         Raises:
             SyntaxError
         """
-        if self._text:
+        if self._text or self._name:
             using = 'link text'
             value = u'name={name}'.format(name=self._text)
+        elif self._value:
+            using = 'link text'
+            value = u'value={value}'.format(value=self._value)
+        elif self._label:
+            using = 'link text'
+            value = u'label={label}'.format(label=self._label)
         elif self._class_name:
             using = 'class name'
             value = self._class_name


### PR DESCRIPTION
expand ‘link text’ query of Selector class with ‘value’ or ‘label’ property, in case no ‘name’ property exists and only ‘value’ property valid
有些iOS App元素存在这种情况：没有name属性，或者name属性为空，或者仅仅是value／label属性有值。Selector类的text入参查询，写死了使用name={name}查询wda，不能处理仅仅value／label属性有值的情况，而使用xpath查询处理的开销略大。因此，扩展了Selector类，支持value、label、name（等价于text）入参查询