### PR TITLE
change  class_name.title() to class_name at init function of class Selector

### DIFF
--- a/wda/__init__.py
+++ b/wda/__init__.py
@@ -298,7 +298,7 @@ class Selector(object):
         self._xpath = unicode(xpath) if xpath else None
         self._index = index
         if class_name and not class_name.startswith('XCUIElementType'):
-            self._class_name = 'XCUIElementType' + class_name.title()
+            self._class_name = 'XCUIElementType' + class_name.encode('utf-8')
         if xpath and not xpath.startswith('//XCUIElementType'):
             element = '|'.join(xcui_element_types.xcui_element)
             self._xpath = re.sub(r'/('+element+')', '/XCUIElementType\g<1>', xpath)

--- a/wda/__init__.py
+++ b/wda/__init__.py
@@ -298,7 +298,7 @@ class Selector(object):
         self._xpath = unicode(xpath) if xpath else None
         self._index = index
         if class_name and not class_name.startswith('XCUIElementType'):
-            self._class_name = 'XCUIElementType' + class_name.encode('utf-8')
+            self._class_name = 'XCUIElementType' + class_name
         if xpath and not xpath.startswith('//XCUIElementType'):
             element = '|'.join(xcui_element_types.xcui_element)
             self._xpath = re.sub(r'/('+element+')', '/XCUIElementType\g<1>', xpath)


### PR DESCRIPTION
修改了 class Selector的初始化函数将 self._class_name = 'XCUIElementType' + class_name.title()中class_name.title()改为class_name 
class_name.title()会把一些class_name的名称中大写字母改为小写 例如 'TextField',－ 'Textfield'等