### PR TITLE
[issue #33]Add escape character for quotes

### DIFF
--- a/wda/__init__.py
+++ b/wda/__init__.py
@@ -597,7 +597,7 @@ class Selector(object):
         self.predicate = predicate
         self.id = id
         self.class_name = className or type
-        self.name = name or text
+        self.name = self._add_escape_character_for_quote_prime_character(name or text)
         self.name_part = nameContains or textContains
         self.name_regex = nameMatches or textMatches
         self.value = value
@@ -626,6 +626,22 @@ class Selector(object):
             return
         re_element = '|'.join(xcui_element_types.ELEMENTS)
         return re.sub(r'/('+re_element+')', '/XCUIElementType\g<1>', s)
+
+    def _add_escape_character_for_quote_prime_character(self, text):
+        """
+        Fix for https://github.com/openatx/facebook-wda/issues/33
+        Returns:
+            string with properly formated quotes, or non changed text
+        """
+        if text is not None:
+          if "'" in text:
+            return text.replace("'","\\'")
+          elif '"' in text:
+            return text.replace('"','\\"')
+          else:
+            return text
+        else:
+            return text
 
     def _wdasearch(self, using, value):
         """


### PR DESCRIPTION
Added method to add escape character. Code was tested locally at:
facebook-wda: master with changes
WebDriverAgent: de4b1d
iPhone: 6s
iOS: 11.0.3
Xcode:9.0.1

With this fix I do not see no longer problems when I'm trying to find text with ' or " character inside searched text:
>>> elements = s(text="it's me")
>>> elements[0].tap(
... )
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/jenkins/jenkins_workspace/workspace/iOS_metropcs_mobile_browser_development_wda_2/ios_tests/tmobile_venv/lib/python2.7/site-packages/wda/__init__.py", line 740, in __getattr__
    return getattr(self.get(), oper)
  File "/Users/jenkins/jenkins_workspace/workspace/iOS_metropcs_mobile_browser_development_wda_2/ios_tests/tmobile_venv/lib/python2.7/site-packages/wda/__init__.py", line 724, in get
    elems = self.find_elements()
  File "/Users/jenkins/jenkins_workspace/workspace/iOS_metropcs_mobile_browser_development_wda_2/ios_tests/tmobile_venv/lib/python2.7/site-packages/wda/__init__.py", line 699, in find_elements
    for element_id in self.find_element_ids():
  File "/Users/jenkins/jenkins_workspace/workspace/iOS_metropcs_mobile_browser_development_wda_2/ios_tests/tmobile_venv/lib/python2.7/site-packages/wda/__init__.py", line 691, in find_element_ids
    return self._wdasearch('class chain', chain)
  File "/Users/jenkins/jenkins_workspace/workspace/iOS_metropcs_mobile_browser_development_wda_2/ios_tests/tmobile_venv/lib/python2.7/site-packages/wda/__init__.py", line 642, in _wdasearch
    for v in self.http.post('/elements', {'using': using, 'value': value}).value:
  File "/Users/jenkins/jenkins_workspace/workspace/iOS_metropcs_mobile_browser_development_wda_2/ios_tests/tmobile_venv/lib/python2.7/site-packages/wda/__init__.py", line 101, in fetch
    return self._fetch_no_alert(method, url, data)
  File "/Users/jenkins/jenkins_workspace/workspace/iOS_metropcs_mobile_browser_development_wda_2/ios_tests/tmobile_venv/lib/python2.7/site-packages/wda/__init__.py", line 107, in _fetch_no_alert
    return httpdo(target_url, method, data)
  File "/Users/jenkins/jenkins_workspace/workspace/iOS_metropcs_mobile_browser_development_wda_2/ios_tests/tmobile_venv/lib/python2.7/site-packages/wda/__init__.py", line 83, in httpdo
    raise WDAError(r.status, r.value)
wda.WDAError: WDAError(status=13, value=Unable to parse the format string "name == 'it's me'"

(
	0   CoreFoundation                      0x00000001838d7d50 <redacted> + 148
	1   libobjc.A.dylib                     0x0000000182dec528 objc_exception_throw + 56
	2   Foundation                          0x00000001841e7fdc <redacted> + 6128
	3   Foundation                          0x00000001841e677c <redacted> + 64
	4   WebDriverAgentLib                   0x0000000104f40d90 +[FBPredicate predicateWithFormat:] + 128
	5   WebDriverAgentLib                   0x0000000104f521b0 +[FBClassChainQueryParser compiledQueryWithTokenizedQuery:originalQuery:error:] + 2780
	6   WebDriverAgentLib                   0x0000000104f52b94 +[FBClassChainQueryParser parseQuery:error:] + 492
	7   WebDriverAgentLib                   0x0000000104f459e4 -[XCUIElement(FBClassChain) fb_descendantsMatchingClassChain:shouldReturnAfterFirstMatch:] + 112
	8   WebDriverAgentLib                   0x0000000104f5f990 +[FBFindElementCommands elementsUsing:withValue:under:shouldReturnAfterFirstMatch:] + 868
	9   WebDriverAgentLib                   0x0000000104f5eb4c +[FBFindElementCommands handleFindElements:] + 344
	10  WebDriverAgentLib                   0x0000000104f4cb54 -[FBRoute_TargetAction mountRequest:intoResponse:] + 208
	11  WebDriverAgentLib                   0x0000000104f449a4 __37-[FBWebServer registerRouteHandlers:]_block_invoke + 496
	12  RoutingHTTPServer                   0x00000001086b23cc -[RoutingHTTPServer handleRoute:withRequest:response:] + 144
	13  RoutingHTTPServer                   0x00000001086b2b80 __72-[RoutingHTTPServer routeMethod:withPath:parameters:request:connection:]_block_invoke + 44
	14  libdispatch.dylib                   0x000000018325d048 <redacted> + 16
	15  libdispatch.dylib                   0x000000018326b2a0 <redacted> + 68
	16  libdispatch.dylib                   0x000000018325d048 <redacted> + 16
	17  libdispatch.dylib                   0x0000000183269b74 <redacted> + 1016
	18  CoreFoundation                      0x000000018387ff20 <redacted> + 12
	19  CoreFoundation                      0x000000018387dafc <redacted> + 2012
	20  CoreFoundation                      0x000000018379e2d8 CFRunLoopRunSpecific + 436
	21  Foundation                          0x00000001841c66e4 <redacted> + 304
	22  WebDriverAgentLib                   0x0000000104f439c4 -[FBWebServer startServing] + 424
	23  WebDriverAgentRunner                0x0000000104c97be4 -[UITestingUITests testRunner] + 132
	24  CoreFoundation                      0x00000001838df6a0 <redacted> + 144
	25  CoreFoundation                      0x00000001837be820 <redacted> + 292
	26  XCTest                              0x00000001042ec0a8 __24-[XCTestCase invokeTest]_block_invoke.275 + 48
	27  XCTest                              0x0000000104338f08 -[XCTMemoryChecker _assertInvalidObjectsDeallocatedAfterScope:] + 56
	28  XCTest                              0x00000001042ebe58 __24-[XCTestCase invokeTest]_block_invoke + 680
	29  XCTest                              0x0000000104331780 -[XCUITestContext performInScope:] + 208
	30  XCTest                              0x00000001042ebba0 -[XCTestCase invokeTest] + 136
	31  XCTest                              0x00000001042ecc78 __26-[XCTestCase performTest:]_block_invoke.382 + 48
	32  XCTest                              0x0000000104336778 +[XCTContext runInContextForTestCase:block:] + 164
	33  XCTest                              0x00000001042ec674 -[XCTestCase performTest:] + 596
	34  XCTest                              0x00000001042e8868 __27-[XCTestSuite performTest:]_block_invoke + 288
	35  XCTest                              0x00000001042e8290 -[XCTestSuite _performProtectedSectionForTest:testSection:] + 44
	36  XCTest                              0x00000001042e84a0 -[XCTestSuite performTest:] + 236
	37  XCTest                              0x00000001042e8868 __27-[XCTestSuite performTest:]_block_invoke + 288
	38  XCTest                              0x00000001042e8290 -[XCTestSuite _performProtectedSectionForTest:testSection:] + 44
	39  XCTest                              0x00000001042e84a0 -[XCTestSuite performTest:] + 236
	40  XCTest                              0x00000001042e8868 __27-[XCTestSuite performTest:]_block_invoke + 288
	41  XCTest                              0x00000001042e8290 -[XCTestSuite _performProtectedSectionForTest:testSection:] + 44
	42  XCTest                              0x00000001042e84a0 -[XCTestSuite performTest:] + 236
	43  XCTest                              0x000000010433ff5c __44-[XCTTestRunSession runTestsAndReturnError:]_block_invoke + 44
	44  XCTest                              0x00000001042fb3e8 -[XCTestObservationCenter _observeTestExecutionForBlock:] + 420
	45  XCTest                              0x000000010433fdd8 -[XCTTestRunSession runTestsAndReturnError:] + 292
	46  XCTest                              0x00000001042d7ed0 -[XCTestDriver runTestsAndReturnError:] + 312
	47  XCTest                              0x0000000104335920 _XCTestMain + 620
	48  CoreFoundation                      0x000000018388016c <redacted> + 20
	49  CoreFoundation                      0x000000018387fa3c <redacted> + 288
	50  CoreFoundation                      0x000000018387d74c <redacted> + 1068
	51  CoreFoundation                      0x000000018379e2d8 CFRunLoopRunSpecific + 436
	52  GraphicsServices                    0x000000018562ff84 GSEventRunModal + 100
	53  UIKit                               0x000000018cd4b880 UIApplicationMain + 208
	54  WebDriverAgentRunner-Runner         0x00000001042c0430 WebDriverAgentRunner-Runner + 33840
	55  libdyld.dylib                       0x00000001832c256c <redacted> + 4
))

