### PR TITLE
callback example fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,7 +529,7 @@ c = wda.Client()
 
 # 使用Example
 def device_offline_callback(client, err):
-	if isinstance(err, requests.ConnectionError, wda.WDABadGateway, requests.ReadTimeout):
+	if isinstance(err, (requests.ConnectionError, wda.WDABadGateway, requests.ReadTimeout)):
 		print("Handle device offline")
 		ok = client.wait_ready(60) # 等待60s恢复
 		if not ok:


### PR DESCRIPTION
isinstance function accepts 2 arguments (an error and a tuple), but supplied 4, the fix is by changing 2nd, 3rd and 4th argument become a tuple