### PR TITLE
Add get_clipboard function.

### DIFF
--- a/wda/__init__.py
+++ b/wda/__init__.py
@@ -782,10 +782,29 @@ class BaseClient(object):
         """
         pass
 
-    # Not working
-    # def get_clipboard(self):
-    #    return self.http.post("/wda/getPasteboard").value
+    def get_clipboard(self, wda_bundle_id):
+        """ Get clipboard text.
 
+        If you want to use this function, you have to set wda foreground which would switch the 
+        current screen of the phone. Then we will try to switch back to the screen before.
+
+        Args:
+            wda_bundle_id: The bundle id of the started wda.
+
+        Returns:
+            Clipboard text.
+        """
+        current_app_bundle_id = self.app_current().get("bundleId", "")
+        # Set wda foreground, it's necessary.
+        try:
+            self.app_launch(wda_bundle_id)
+        except:
+            pass
+        clipboard_text = self._session_http.post("/wda/getPasteboard").value
+        # Switch back to the screen before.
+        self.app_launch(current_app_bundle_id)
+        return base64.b64decode(clipboard_text).decode('utf-8')
+    
     # Not working
     # def siri_activate(self, text):
     #    self.http.post("/wda/siri/activate", {"text": text})


### PR DESCRIPTION
wda提供的getPasteboard并不是完全不能用，而是需要将手机上安装的wda设置为foreground时才能生效，也就是点击一下wda的app让它成为当前的app。所以代码里通过app_launch来将wda设置为foreground，获取剪切板内容后，再切换回原来的app。
![image](https://github.com/openatx/facebook-wda/assets/51052388/1d984f85-7fc0-499c-bca2-497daef68c6b)
