### PR TITLE
UsbmuxHTTPConnection Error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ retry
 Pillow
 cached-property~=1.5.1
 Deprecated~=1.2.6
+urllib3==1.26.18 


### PR DESCRIPTION
Starting from version 2, the implementation of 'request' in urllib3 has changed. It is necessary to fix the version number; otherwise, the 'connect' function of the 'UsbmuxHTTPConnection' class will never be called.