### PR TITLE
usbmux: make fetch Python 3.7 compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ ENV/
 .vscode
 .DS_Store
 xcuserdata/
+
+# IDE
+.idea/


### PR DESCRIPTION
* Fixes breaking python 3.7 change introduced by: f6e93b597b8f71cc31792abe9520a5cb50b2a4c0
* Addresses: https://github.com/openatx/facebook-wda/issues/152

## Tested
* iOS16 and 17
* python 3.7 and 3.9

Launched WDA app separately
```
export DEVICE_URL="http://192.168.2.58:8100"
pytest -k test_client_status tests
```

Also modified two tests locally
* test_element_scroll_visible - removed pytest.skip decorator
* test_element_name_matches - changed mandarin to english "蓝牙" -> "Bluetooth"

