### PR TITLE
fix: add `__eq__` to `Element` to align comparison behavior with WebD…

### DIFF
--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -1,0 +1,33 @@
+import uuid
+
+import pytest
+
+from wda import Element, Client, Selector
+
+
+@pytest.fixture
+def mock_client(monkeypatch):
+    yield Client()
+
+
+def test_eq(mock_client):
+    el1 = Element(session=mock_client, id=uuid.uuid4().hex)
+    el2 = Element(session=mock_client, id=uuid.uuid4().hex)
+    assert el1 != el2
+    assert el1 == el1
+
+
+def test_find_elements_eq(mock_client, monkeypatch):
+    el = Element(session=mock_client, id=uuid.uuid4().hex)
+    monkeypatch.setattr(Selector, "find_element_ids", lambda *args, **kwargs: [el])
+    el1 = mock_client(type="XCUIElementTypeStaticText").get(0)
+    el2 = mock_client(type="XCUIElementTypeStaticText").get(0)
+    assert el1 == el2
+
+def test_find_elements_not_eq(mock_client, monkeypatch):
+    def find_element_ids(*args, **kwargs):
+        return [Element(session=mock_client, id=uuid.uuid4().hex)]
+    monkeypatch.setattr(Selector, "find_element_ids", find_element_ids)
+    el1 = mock_client(type="XCUIElementTypeStaticText").get(0)
+    el2 = mock_client(type="XCUIElementTypeStaticText").get(0)
+    assert el1 != el2

--- a/wda/__init__.py
+++ b/wda/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function, unicode_literals
+from __future__ import print_function, unicode_literals,annotations
 
 import base64
 import contextlib
@@ -1584,6 +1584,9 @@ class Element(object):
 
     def __repr__(self):
         return '<wda.Element(id="{}")>'.format(self._id)
+
+    def __eq__(self, other: Element):
+        return self._id == other._id
 
     @property
     def http(self):


### PR DESCRIPTION
…river/Appium standards